### PR TITLE
Fix core team document link

### DIFF
--- a/docs/development/maintaining/maintainer.md
+++ b/docs/development/maintaining/maintainer.md
@@ -52,7 +52,7 @@ our maintainers to help push the project forward.
 If Karan has offered you the position of becoming a maintainer, we will ask you the following 
 questions. These questions help us both set the expectations.
 
-As explained in the [core team document](https://github.com/Project-Books/book-project/blob/master/docs/maintainers/CORE_TEAM.md), 
+As explained in the [core team document](https://project-books.github.io/development/maintaining/core-team/), 
 we appreciate that becoming a maintainer is a big commitment (and we are very appreciative of our 
 maintainers). We want to be flexible to respect your other commitments. If your availability 
 changes, that's fine. The important thing is to let us know so that we can continue to be respectful


### PR DESCRIPTION
Fix `core team document` link on the [Becoming a maintainer](https://project-books.github.io/development/maintaining/maintainer/) page to correctly point to https://project-books.github.io/development/maintaining/core-team/
Resolves #20 